### PR TITLE
chore: release

### DIFF
--- a/crates/rdi-parser/CHANGELOG.md
+++ b/crates/rdi-parser/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/samscott89/rust_debuginfo/releases/tag/rdi-parser-v0.1.0) - 2025-06-27
+
+### Other
+
+- Reading of BTreeMap values
+- New internal struct for btrees
+- More enum helper parsers
+- Go back to more specialized option/result parsing
+- More WIP...
+- Formatting
+- BTree parsing
+- Slice + better enum/option/result handling
+- Some initial method discovery
+- More expression work
+- WIP complex expressions
+- Pull parser + type defs out of rust-debuginfo crate

--- a/crates/rust-types/CHANGELOG.md
+++ b/crates/rust-types/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/samscott89/rust_debuginfo/compare/rust-types-v0.1.0...rust-types-v0.2.0) - 2025-06-27
+
+### Other
+
+- Reading of BTreeMap values
+- New internal struct for btrees
+- Enum parsing + reading
+- More enum helper parsers
+- Go back to more specialized option/result parsing
+- More WIP...
+- BTree parsing
+- Slice + better enum/option/result handling
+- Some initial method discovery
+- Finish field expressions
+- Slightly cleaner eval structure
+- Pull parser + type defs out of rust-debuginfo crate

--- a/crates/rust-types/Cargo.toml
+++ b/crates/rust-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-types"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/rdi-lldb/CHANGELOG.md
+++ b/rdi-lldb/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/samscott89/rust_debuginfo/releases/tag/rdi-lldb-v0.1.0) - 2025-06-27
+
+### Other
+
+- Enum parsing + reading
+- Formatting
+- Some initial method discovery
+- Skeleton of methods command
+- Finish field expressions
+- More expression work
+- Slightly cleaner eval structure
+- Parse more expressions
+- Minor fixes
+- More type resolution, pretty printing, hooked up with `rdi` command
+- HashMap reading working
+- Basic value printing working
+- Hook it up to rust-debuginfo
+- Remove hex string from protocol
+- Initial expression evaluation
+- Address type/lint errors
+- rdi-lldb basic flow
+- Iniitial protocol
+- Restructure repo to split rust-debuginfo lib + rdi-lldb bin crate

--- a/rust-debuginfo/CHANGELOG.md
+++ b/rust-debuginfo/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/samscott89/rust_debuginfo/releases/tag/rust-debuginfo-v0.0.1) - 2025-06-27
+
+### Other
+
+- Reading of BTreeMap values
+- Get option/result working again
+- New internal struct for btrees
+- WIP btreemap parsing
+- Enum parsing + reading
+- More enum helper parsers
+- Go back to more specialized option/result parsing
+- Macro for tuples
+- More parser stuff
+- Re-org parser
+- Refactor option parser to combinators
+- combinators for hashmap impl
+- More fun with combinators
+- Children combinator working
+- Bulk parsing
+- Nice POC of using it
+- POC parser combinator for DWARF
+- More WIP...
+- WIP
+- Add (failing) btree introspection
+- Fix tests
+- BTree parsing
+- Slice + better enum/option/result handling
+- Some initial method discovery
+- Finish field expressions
+- More expression work
+- WIP complex expressions
+- Pull parser + type defs out of rust-debuginfo crate
+- lazily index types, fix tests + run benchmarks
+- Minor fixes
+- More type resolution, pretty printing, hooked up with `rdi` command
+- More hashmap support
+- HashMap reading working
+- Smart pointers
+- Clean up error handling
+- More type resolution + data reading
+- Resolve options
+- Inspect strings
+- Working vec
+- WIP reading from memory.
+- Closer
+- Make positions work again
+- Addresses in a map
+- slimmer, more efficient index
+- Some nits
+- Add some live introspection tests
+- Hand roll a simple symbol parser
+- More parsing
+- More parsing
+- More type handling
+- Mostly just some nicer names in snapshots
+- Refactoring
+- Add some tests
+- Parse TypeDef from names in dwarfinfo
+- Remove lifetimes from typedefs
+- Some pretty printing
+- Implement parsing with `unsynn` for symbols + types
+- A little more type parsing stuff
+- Tests for std type detection
+- getting std type resolution working
+- Basic value printing working
+- Move binaries to bin/ folder
+- rdi-lldb basic flow
+- Iniitial protocol
+- Restructure repo to split rust-debuginfo lib + rdi-lldb bin crate


### PR DESCRIPTION



## 🤖 New release

* `rust-types`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `rdi-parser`: 0.1.0
* `rust-debuginfo`: 0.0.1
* `rdi-lldb`: 0.1.0

### ⚠ `rust-types` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum rust_types::ledger_models::security::CouponFrequencyProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:93
  enum rust_types::ledger_models::position::PositionFilterOperator, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:174
  enum rust_types::ledger_models::position::PositionViewProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:224
  enum rust_types::ledger_models::position::PositionTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:244
  enum rust_types::ledger_models::security::SecurityQuantityTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:70
  enum rust_types::ledger_models::security::IdentifierTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:3
  enum rust_types::ledger_models::security::TenorTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:192
  enum rust_types::ledger_models::position::field_map_entry::FieldMapValueOneOf, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:163
  enum rust_types::ledger_models::security::CouponTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:120
  enum rust_types::ledger_models::position::PositionStatusProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:3
  enum rust_types::ledger_models::position::MeasureProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:28
  enum rust_types::ledger_models::position::FieldProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:52
  enum rust_types::ledger_models::util::RequestOperationTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/util.rs:35
  enum rust_types::ledger_models::transaction::TransactionTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/transaction.rs:3
  enum rust_types::ledger_models::security::SecurityTypeProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:43

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/module_missing.ron

Failed in:
  mod rust_types::ledger_models::valuation, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/valuation.rs:1
  mod rust_types::ledger_models::position, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:1
  mod rust_types::ledger_models::position::field_map_entry, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:161
  mod rust_types::ledger_models::portfolio, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/portfolio.rs:1
  mod rust_types::ledger_models::security, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:1
  mod rust_types::ledger_models::strategy, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/strategy.rs:1
  mod rust_types::ledger_models::util, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/util.rs:1
  mod rust_types::ledger_models::transaction, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/transaction.rs:1
  mod rust_types::ledger_models::valuation::valuation_client, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/valuation.rs:2
  mod rust_types::ledger_models::valuation::valuation_server, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/valuation.rs:97
  mod rust_types::ledger_models, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/mod.rs:1
  mod rust_types::ledger_models::price, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/price.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct rust_types::ledger_models::position::MeasureMapFieldEntry, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:201
  struct rust_types::ledger_models::security::IdentifierProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:30
  struct rust_types::ledger_models::security::SecurityResponseProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:239
  struct rust_types::ledger_models::price::PriceProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/price.rs:2
  struct rust_types::ledger_models::valuation::valuation_client::ValuationClient, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/valuation.rs:7
  struct rust_types::ledger_models::util::DecimalValueProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/util.rs:2
  struct rust_types::ledger_models::position::PositionResponseProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:293
  struct rust_types::ledger_models::valuation::valuation_server::ValuationServer, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/valuation.rs:112
  struct rust_types::ledger_models::util::UuidProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/util.rs:29
  struct rust_types::ledger_models::position::FieldMapEntry, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:149
  struct rust_types::ledger_models::transaction::TransactionRequestProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/transaction.rs:77
  struct rust_types::ledger_models::portfolio::PortfolioRequestProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/portfolio.rs:19
  struct rust_types::ledger_models::transaction::TransactionProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/transaction.rs:30
  struct rust_types::ledger_models::util::LocalDateProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/util.rs:11
  struct rust_types::ledger_models::security::SecurityProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:142
  struct rust_types::ledger_models::portfolio::PortfolioResponseProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/portfolio.rs:36
  struct rust_types::ledger_models::position::PositionRequestProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:272
  struct rust_types::ledger_models::security::SecurityRequestProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:222
  struct rust_types::ledger_models::strategy::StrategyAllocationProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/strategy.rs:28
  struct rust_types::ledger_models::position::PositionFilterProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:263
  struct rust_types::ledger_models::util::LocalTimestampProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/util.rs:20
  struct rust_types::ledger_models::portfolio::PortfolioProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/portfolio.rs:2
  struct rust_types::ledger_models::security::TenorProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/security.rs:211
  struct rust_types::ledger_models::strategy::StrategyProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/strategy.rs:2
  struct rust_types::ledger_models::position::PositionProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/position.rs:208
  struct rust_types::ledger_models::transaction::TransactionResponseProto, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/transaction.rs:94
  struct rust_types::ledger_models::strategy::MapFieldEntry, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/strategy.rs:21

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_missing.ron

Failed in:
  trait rust_types::ledger_models::valuation::valuation_server::Valuation, previously in file /tmp/.tmp58hcoW/rust-types/src/ledger_models/valuation.rs:102
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rust-types`

<blockquote>

## [0.2.0](https://github.com/samscott89/rust_debuginfo/compare/rust-types-v0.1.0...rust-types-v0.2.0) - 2025-06-27

### Other

- Reading of BTreeMap values
- New internal struct for btrees
- Enum parsing + reading
- More enum helper parsers
- Go back to more specialized option/result parsing
- More WIP...
- BTree parsing
- Slice + better enum/option/result handling
- Some initial method discovery
- Finish field expressions
- Slightly cleaner eval structure
- Pull parser + type defs out of rust-debuginfo crate
</blockquote>

## `rdi-parser`

<blockquote>

## [0.1.0](https://github.com/samscott89/rust_debuginfo/releases/tag/rdi-parser-v0.1.0) - 2025-06-27

### Other

- Reading of BTreeMap values
- New internal struct for btrees
- More enum helper parsers
- Go back to more specialized option/result parsing
- More WIP...
- Formatting
- BTree parsing
- Slice + better enum/option/result handling
- Some initial method discovery
- More expression work
- WIP complex expressions
- Pull parser + type defs out of rust-debuginfo crate
</blockquote>

## `rust-debuginfo`

<blockquote>

## [0.0.1](https://github.com/samscott89/rust_debuginfo/releases/tag/rust-debuginfo-v0.0.1) - 2025-06-27

### Other

- Reading of BTreeMap values
- Get option/result working again
- New internal struct for btrees
- WIP btreemap parsing
- Enum parsing + reading
- More enum helper parsers
- Go back to more specialized option/result parsing
- Macro for tuples
- More parser stuff
- Re-org parser
- Refactor option parser to combinators
- combinators for hashmap impl
- More fun with combinators
- Children combinator working
- Bulk parsing
- Nice POC of using it
- POC parser combinator for DWARF
- More WIP...
- WIP
- Add (failing) btree introspection
- Fix tests
- BTree parsing
- Slice + better enum/option/result handling
- Some initial method discovery
- Finish field expressions
- More expression work
- WIP complex expressions
- Pull parser + type defs out of rust-debuginfo crate
- lazily index types, fix tests + run benchmarks
- Minor fixes
- More type resolution, pretty printing, hooked up with `rdi` command
- More hashmap support
- HashMap reading working
- Smart pointers
- Clean up error handling
- More type resolution + data reading
- Resolve options
- Inspect strings
- Working vec
- WIP reading from memory.
- Closer
- Make positions work again
- Addresses in a map
- slimmer, more efficient index
- Some nits
- Add some live introspection tests
- Hand roll a simple symbol parser
- More parsing
- More parsing
- More type handling
- Mostly just some nicer names in snapshots
- Refactoring
- Add some tests
- Parse TypeDef from names in dwarfinfo
- Remove lifetimes from typedefs
- Some pretty printing
- Implement parsing with `unsynn` for symbols + types
- A little more type parsing stuff
- Tests for std type detection
- getting std type resolution working
- Basic value printing working
- Move binaries to bin/ folder
- rdi-lldb basic flow
- Iniitial protocol
- Restructure repo to split rust-debuginfo lib + rdi-lldb bin crate
</blockquote>

## `rdi-lldb`

<blockquote>

## [0.1.0](https://github.com/samscott89/rust_debuginfo/releases/tag/rdi-lldb-v0.1.0) - 2025-06-27

### Other

- Enum parsing + reading
- Formatting
- Some initial method discovery
- Skeleton of methods command
- Finish field expressions
- More expression work
- Slightly cleaner eval structure
- Parse more expressions
- Minor fixes
- More type resolution, pretty printing, hooked up with `rdi` command
- HashMap reading working
- Basic value printing working
- Hook it up to rust-debuginfo
- Remove hex string from protocol
- Initial expression evaluation
- Address type/lint errors
- rdi-lldb basic flow
- Iniitial protocol
- Restructure repo to split rust-debuginfo lib + rdi-lldb bin crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).