### PR TITLE
chore: release

### DIFF
--- a/crates/rudy-parser/CHANGELOG.md
+++ b/crates/rudy-parser/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-parser-v0.1.0) - 2025-06-27
+
+### Other
+
+- Clippy
+- Misc
+- Fix a few tests
+- Fix path
+- Rename to Rudy. Clean up some old examples.

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-types-v0.1.0) - 2025-06-27
+
+### Other
+
+- Clippy
+- Fix a few tests
+- Rename to Rudy. Clean up some old examples.

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1](https://github.com/samscott89/rudy/releases/tag/rudy-db-v0.0.1) - 2025-06-27
+
+### Other
+
+- Clippy
+- Misc
+- Fix a few tests
+- Update all snapshots
+- s/rust_types/rudy_types/g
+- Rename to Rudy. Clean up some old examples.

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-lldb-v0.1.0) - 2025-06-27
+
+### Other
+
+- Clippy
+- Fix a few tests
+- s/rust_types/rudy_types/g
+- Rename to Rudy. Clean up some old examples.


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.1.0
* `rudy-parser`: 0.1.0
* `rudy-db`: 0.0.1
* `rudy-lldb`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-types-v0.1.0) - 2025-06-27

### Other

- Clippy
- Fix a few tests
- Rename to Rudy. Clean up some old examples.
</blockquote>

## `rudy-parser`

<blockquote>

## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-parser-v0.1.0) - 2025-06-27

### Other

- Clippy
- Misc
- Fix a few tests
- Fix path
- Rename to Rudy. Clean up some old examples.
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.1](https://github.com/samscott89/rudy/releases/tag/rudy-db-v0.0.1) - 2025-06-27

### Other

- Clippy
- Misc
- Fix a few tests
- Update all snapshots
- s/rust_types/rudy_types/g
- Rename to Rudy. Clean up some old examples.
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-lldb-v0.1.0) - 2025-06-27

### Other

- Clippy
- Fix a few tests
- s/rust_types/rudy_types/g
- Rename to Rudy. Clean up some old examples.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).