### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.1", path = "rudy-db" }
+rudy-db = { version = "0.0.2", path = "rudy-db" }
 rudy-types = { version = "0.1", path = "crates/rudy-types" }
 rudy-parser = { version = "0.1", path = "crates/rudy-parser" }
 

--- a/crates/rudy-parser/CHANGELOG.md
+++ b/crates/rudy-parser/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/samscott89/rudy/compare/rudy-parser-v0.1.0...rudy-parser-v0.1.1) - 2025-06-27
+
+### Other
+
+- Change for publishing to crates.io
+- Simplify all changelogs
+- release
+- Clippy 1.88 fixes!
+- Clippy
+- Misc
+- Fix a few tests
+- Fix path
+- Rename to Rudy. Clean up some old examples.
+
 ## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-parser-v0.1.0) - 2025-06-27
 
 Initial release!

--- a/crates/rudy-parser/Cargo.toml
+++ b/crates/rudy-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rudy-parser"
 description = "Simple Rust type and expression parser for Rudy"
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/samscott89/rudy/compare/rudy-types-v0.1.0...rudy-types-v0.1.1) - 2025-06-27
+
+### Other
+
+- Change for publishing to crates.io
+- Simplify all changelogs
+- release
+- Clippy 1.88 fixes!
+- Formatting
+- Clippy
+- Fix a few tests
+- Rename to Rudy. Clean up some old examples.
+
 ## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-types-v0.1.0) - 2025-06-27
 
 Initial release!

--- a/crates/rudy-types/Cargo.toml
+++ b/crates/rudy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Type layouts of common Rust types for Rudy"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.1...rudy-db-v0.0.2) - 2025-06-27
+
+### Other
+
+- Change for publishing to crates.io
+- Simplify all changelogs
+- release
+- Formatting
+- Clippy 1.88 fixes!
+- Formatting
+- Update snapshots for Rust 1.88
+- Clippy
+- Misc
+- Fix a few tests
+- Update all snapshots
+- s/rust_types/rudy_types/g
+- Header styling
+- Add logo
+- Rename to Rudy. Clean up some old examples.
+- Restructure repo to split rust-debuginfo lib + rdi-lldb bin crate
+- Documentation
+- Initial commit
+
 ## [0.0.1](https://github.com/samscott89/rudy/releases/tag/rudy-db-v0.0.1) - 2025-06-27
 
 Initial release!

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.0...rudy-lldb-v0.1.1) - 2025-06-27
+
+### Other
+
+- Change for publishing to crates.io
+- Simplify all changelogs
+- release
+- Clippy 1.88 fixes!
+- Clippy
+- Fix a few tests
+- s/rust_types/rudy_types/g
+- Rename to Rudy. Clean up some old examples.
+
 ## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-lldb-v0.1.0) - 2025-06-27
 
 Initial release!

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `rudy-parser`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `rudy-db`: 0.0.1 -> 0.0.2 (✓ API compatible changes)
* `rudy-lldb`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.1.1](https://github.com/samscott89/rudy/compare/rudy-types-v0.1.0...rudy-types-v0.1.1) - 2025-06-27

### Other

- Change for publishing to crates.io
- Simplify all changelogs
- release
- Clippy 1.88 fixes!
- Formatting
- Clippy
- Fix a few tests
- Rename to Rudy. Clean up some old examples.
</blockquote>

## `rudy-parser`

<blockquote>

## [0.1.1](https://github.com/samscott89/rudy/compare/rudy-parser-v0.1.0...rudy-parser-v0.1.1) - 2025-06-27

### Other

- Change for publishing to crates.io
- Simplify all changelogs
- release
- Clippy 1.88 fixes!
- Clippy
- Misc
- Fix a few tests
- Fix path
- Rename to Rudy. Clean up some old examples.
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.2](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.1...rudy-db-v0.0.2) - 2025-06-27

### Other

- Change for publishing to crates.io
- Simplify all changelogs
- release
- Formatting
- Clippy 1.88 fixes!
- Formatting
- Update snapshots for Rust 1.88
- Clippy
- Misc
- Fix a few tests
- Update all snapshots
- s/rust_types/rudy_types/g
- Header styling
- Add logo
- Rename to Rudy. Clean up some old examples.
- Restructure repo to split rust-debuginfo lib + rdi-lldb bin crate
- Documentation
- Initial commit
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.1](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.0...rudy-lldb-v0.1.1) - 2025-06-27

### Other

- Change for publishing to crates.io
- Simplify all changelogs
- release
- Clippy 1.88 fixes!
- Clippy
- Fix a few tests
- s/rust_types/rudy_types/g
- Rename to Rudy. Clean up some old examples.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).