### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.3", path = "rudy-db" }
+rudy-db = { version = "0.0.4", path = "rudy-db" }
 rudy-dwarf = { version = "0.1.0", path = "crates/rudy-dwarf" }
 rudy-types = { version = "0.2", path = "crates/rudy-types" }
 rudy-parser = { version = "0.2", path = "crates/rudy-parser" }

--- a/crates/rudy-parser/CHANGELOG.md
+++ b/crates/rudy-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/samscott89/rudy/compare/rudy-parser-v0.2.0...rudy-parser-v0.2.1) - 2025-07-01
+
+### Other
+
+- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
+
 ## [0.2.0](https://github.com/samscott89/rudy/compare/rudy-parser-v0.1.0...rudy-parser-v0.2.0) - 2025-06-29
 
 ## [0.1.0](https://github.com/samscott89/rudy/releases/tag/rudy-parser-v0.1.0) - 2025-06-27

--- a/crates/rudy-parser/Cargo.toml
+++ b/crates/rudy-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rudy-parser"
 description = "Simple Rust type and expression parser for Rudy"
 license = "MIT"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/samscott89/rudy/compare/rudy-types-v0.2.1...rudy-types-v0.2.2) - 2025-07-01
+
+### Other
+
+- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
+
 ## [0.2.1](https://github.com/samscott89/rudy/compare/rudy-types-v0.2.0...rudy-types-v0.2.1) - 2025-07-01
 
 ### Other

--- a/crates/rudy-types/Cargo.toml
+++ b/crates/rudy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-types"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "Type layouts of common Rust types for Rudy"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.4](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.3...rudy-db-v0.0.4) - 2025-07-01
+
+### Other
+
+- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
+
 ## [0.0.3](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.2...rudy-db-v0.0.3) - 2025-07-01
 
 ### Other

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.2...rudy-lldb-v0.1.3) - 2025-07-01
+
+### Other
+
+- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
+
 ## [0.1.2](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.1...rudy-lldb-v0.1.2) - 2025-07-01
 
 ### Other

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `rudy-parser`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `rudy-db`: 0.0.3 -> 0.0.4 (⚠ API breaking changes)
* `rudy-lldb`: 0.1.2 -> 0.1.3

### ⚠ `rudy-db` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum rudy_db::SelfType, previously in file /tmp/.tmpN4MtEp/rudy-db/src/types.rs:21

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct rudy_db::Symbol, previously in file /tmp/.tmpN4MtEp/rudy-db/src/index/symbols.rs:16
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.2.2](https://github.com/samscott89/rudy/compare/rudy-types-v0.2.1...rudy-types-v0.2.2) - 2025-07-01

### Other

- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
</blockquote>

## `rudy-parser`

<blockquote>

## [0.2.1](https://github.com/samscott89/rudy/compare/rudy-parser-v0.2.0...rudy-parser-v0.2.1) - 2025-07-01

### Other

- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.4](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.3...rudy-db-v0.0.4) - 2025-07-01

### Other

- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.3](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.2...rudy-lldb-v0.1.3) - 2025-07-01

### Other

- Refactor core dwarf features into `rudy-dwarf` ([#11](https://github.com/samscott89/rudy/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).