### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ resolver = "3"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.5", path = "rudy-db" }
-rudy-dwarf = { version = "0.2.0", path = "crates/rudy-dwarf" }
-rudy-types = { version = "0.3", path = "crates/rudy-types" }
-rudy-parser = { version = "0.3", path = "crates/rudy-parser" }
+rudy-db = { version = "0.0.6", path = "rudy-db" }
+rudy-dwarf = { version = "0.3.0", path = "crates/rudy-dwarf" }
+rudy-types = { version = "0.4", path = "crates/rudy-types" }
+rudy-parser = { version = "0.4", path = "crates/rudy-parser" }
 rudy-test-examples = { path = "crates/rudy-test-examples" }
 test-utils = { path = "crates/test-utils" }
 

--- a/crates/rudy-dwarf/CHANGELOG.md
+++ b/crates/rudy-dwarf/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.2.0...rudy-dwarf-v0.3.0) - 2025-07-07
+
+### Other
+
+- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
+- Support passing arguments to functions/methods ([#22](https://github.com/samscott89/rudy/pull/22))
+- Add function calling ([#21](https://github.com/samscott89/rudy/pull/21))
+- Simplify lifetimes ([#19](https://github.com/samscott89/rudy/pull/19))
+
 ## [0.2.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.1.0...rudy-dwarf-v0.2.0) - 2025-07-03
 
 ### Other

--- a/crates/rudy-dwarf/Cargo.toml
+++ b/crates/rudy-dwarf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-dwarf"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "DWARF debug information parsing and querying for Rust debugging tools"
 license = "MIT"

--- a/crates/rudy-parser/CHANGELOG.md
+++ b/crates/rudy-parser/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-parser-v0.3.0...rudy-parser-v0.4.0) - 2025-07-07
+
+### Other
+
+- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
+- Support paths + generics ([#25](https://github.com/samscott89/rudy/pull/25))
+
 ## [0.3.0](https://github.com/samscott89/rudy/compare/rudy-parser-v0.2.1...rudy-parser-v0.3.0) - 2025-07-03
 
 ### Other

--- a/crates/rudy-parser/Cargo.toml
+++ b/crates/rudy-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rudy-parser"
 description = "Simple Rust type and expression parser for Rudy"
 license = "MIT"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-types-v0.3.0...rudy-types-v0.4.0) - 2025-07-07
+
+### Other
+
+- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
+
 ## [0.3.0](https://github.com/samscott89/rudy/compare/rudy-types-v0.2.2...rudy-types-v0.3.0) - 2025-07-03
 
 ### Other

--- a/crates/rudy-types/Cargo.toml
+++ b/crates/rudy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-types"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "Type layouts of common Rust types for Rudy"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.6](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.5...rudy-db-v0.0.6) - 2025-07-07
+
+### Other
+
+- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
+- Support passing arguments to functions/methods ([#22](https://github.com/samscott89/rudy/pull/22))
+- Add function calling ([#21](https://github.com/samscott89/rudy/pull/21))
+- Simplify lifetimes ([#19](https://github.com/samscott89/rudy/pull/19))
+
 ## [0.0.5](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.4...rudy-db-v0.0.5) - 2025-07-03
 
 ### Other

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.4...rudy-lldb-v0.1.5) - 2025-07-07
+
+### Other
+
+- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
+- Support paths + generics ([#25](https://github.com/samscott89/rudy/pull/25))
+- Support searching for methods by a type name ([#23](https://github.com/samscott89/rudy/pull/23))
+- Support passing arguments to functions/methods ([#22](https://github.com/samscott89/rudy/pull/22))
+- Add function calling ([#21](https://github.com/samscott89/rudy/pull/21))
+- Simplify lifetimes ([#19](https://github.com/samscott89/rudy/pull/19))
+
 ## [0.1.4](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.3...rudy-lldb-v0.1.4) - 2025-07-03
 
 ### Other

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `rudy-parser`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `rudy-dwarf`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `rudy-db`: 0.0.5 -> 0.0.6 (⚠ API breaking changes)
* `rudy-lldb`: 0.1.4 -> 0.1.5

### ⚠ `rudy-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VecLayout.capacity_offset in /tmp/.tmpcYB5WH/rudy/crates/rudy-types/src/lib.rs:790
```

### ⚠ `rudy-parser` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Expression:Path in /tmp/.tmpcYB5WH/rudy/crates/rudy-parser/src/expressions.rs:19
  variant Expression:Generic in /tmp/.tmpcYB5WH/rudy/crates/rudy-parser/src/expressions.rs:22
  variant Expression:Path in /tmp/.tmpcYB5WH/rudy/crates/rudy-parser/src/expressions.rs:19
  variant Expression:Generic in /tmp/.tmpcYB5WH/rudy/crates/rudy-parser/src/expressions.rs:22
```

### ⚠ `rudy-dwarf` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type FunctionSignature no longer derives Copy, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/mod.rs:171
  type Variable no longer derives Copy, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/variables.rs:22
  type SourceFile no longer derives Copy, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:205
  type SourceFile no longer derives Copy, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:205
  type SourceLocation no longer derives Copy, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:21

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  FunctionSignature::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::name, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::params, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::return_type, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::self_type, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::callable, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::debug_location, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  FunctionSignature::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/mod.rs:170
  Variable::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/variables.rs:21
  Variable::name, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/variables.rs:21
  Variable::ty, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/variables.rs:21
  Variable::location, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/variables.rs:21
  Variable::origin, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/variables.rs:21
  Variable::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/function/variables.rs:21
  SourceFile::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:198
  SourceFile::path, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:198
  SourceFile::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:198
  SourceFile::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:198
  SourceFile::path, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:198
  SourceFile::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:198
  SourceLocation::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:20
  SourceLocation::file, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:20
  SourceLocation::line, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:20
  SourceLocation::column, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:20
  SourceLocation::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/file/mod.rs:20
  Die::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/die/mod.rs:26
  Die::new, previously in file /tmp/.tmptWP828/rudy-dwarf/src/die/mod.rs:26
  Die::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/die/mod.rs:26
  Die::ingredient, previously in file /tmp/.tmptWP828/rudy-dwarf/src/die/mod.rs:26
  Die::new, previously in file /tmp/.tmptWP828/rudy-dwarf/src/die/mod.rs:26
  Die::default_debug_fmt, previously in file /tmp/.tmptWP828/rudy-dwarf/src/die/mod.rs:26

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rudy_dwarf::function::FunctionSignature::new now takes 6 parameters instead of 7, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/mod.rs:196
  rudy_dwarf::function::FunctionSignature::print_sig now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/mod.rs:216
  rudy_dwarf::function::Variable::new now takes 4 parameters instead of 5, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/variables.rs:31
  rudy_dwarf::file::SourceFile::new now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:210
  rudy_dwarf::file::SourceFile::path_str now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:214
  rudy_dwarf::file::SourceFile::is_external now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:218
  rudy_dwarf::SourceFile::new now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:210
  rudy_dwarf::SourceFile::path_str now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:214
  rudy_dwarf::SourceFile::is_external now takes 1 parameters instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:218
  rudy_dwarf::file::SourceLocation::new now takes 3 parameters instead of 4, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:28

--- failure method_requires_different_generic_type_params: method now requires a different number of generic type parameters ---

Description:
A method now requires a different number of generic type parameters than it used to. Uses of this method that supplied the previous number of generic types will be broken.
        ref: https://doc.rust-lang.org/reference/items/generics.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_requires_different_generic_type_params.ron

Failed in:
  rudy_dwarf::function::FunctionSignature::new takes 0 generic types instead of 1, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/mod.rs:196
  rudy_dwarf::function::Variable::new takes 0 generic types instead of 1, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/variables.rs:31
  rudy_dwarf::file::SourceFile::new takes 0 generic types instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:210
  rudy_dwarf::SourceFile::new takes 0 generic types instead of 2, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:210
  rudy_dwarf::file::SourceLocation::new takes 0 generic types instead of 4, in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:28

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_missing.ron

Failed in:
  struct rudy_dwarf::types::resolve_type_offset, previously in file /tmp/.tmptWP828/rudy-dwarf/src/types/resolution.rs:531
  struct rudy_dwarf::modules::get_containing_module, previously in file /tmp/.tmptWP828/rudy-dwarf/src/modules.rs:258

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method map_with_db_and_entry of trait Parser, previously in file /tmp/.tmptWP828/rudy-dwarf/src/parser/mod.rs:73

--- failure trait_mismatched_generic_lifetimes: trait now takes a different number of generic lifetimes ---

Description:
A trait now takes a different number of generic lifetime parameters. Uses of this trait that name the previous number of parameters, such as in trait bounds, will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_mismatched_generic_lifetimes.ron
Failed in:
  trait Parser (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/parser/mod.rs:30

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct FunctionSignature (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/mod.rs:171
  Struct Variable (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/variables.rs:22
  Struct Module (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/modules.rs:10
  Struct SourceFile (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:205
  Struct SourceFile (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:205
  Struct SourceLocation (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/file/mod.rs:21
  Struct Die (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/die/mod.rs:27
  Struct Die (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/die/mod.rs:27
  Struct FunctionInfo (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/parser/functions.rs:12
  Struct FunctionData (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/function/index.rs:23
  Struct ModuleRange (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/modules.rs:55
  Struct ParameterInfo (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/crates/rudy-dwarf/src/parser/functions.rs:22
```

### ⚠ `rudy-db` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DiscoveredMethod.parameters in /tmp/.tmpcYB5WH/rudy/rudy-db/src/outputs.rs:261

--- failure type_mismatched_generic_lifetimes: type now takes a different number of generic lifetimes ---

Description:
A type now takes a different number of generic lifetime parameters. Uses of this type that name the previous number of parameters will be broken.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/type_mismatched_generic_lifetimes.ron
Failed in:
  Struct Variable (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/rudy-db/src/outputs.rs:31
  Struct VariableInfo (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/rudy-db/src/outputs.rs:39
  Enum Value (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/rudy-db/src/outputs.rs:68
  Struct DiscoveredMethod (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/rudy-db/src/outputs.rs:243
  Struct TypedPointer (1 -> 0 lifetime params) in /tmp/.tmpcYB5WH/rudy/rudy-db/src/outputs.rs:59
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-types-v0.3.0...rudy-types-v0.4.0) - 2025-07-07

### Other

- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
</blockquote>

## `rudy-parser`

<blockquote>

## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-parser-v0.3.0...rudy-parser-v0.4.0) - 2025-07-07

### Other

- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
- Support paths + generics ([#25](https://github.com/samscott89/rudy/pull/25))
</blockquote>

## `rudy-dwarf`

<blockquote>

## [0.3.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.2.0...rudy-dwarf-v0.3.0) - 2025-07-07

### Other

- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
- Support passing arguments to functions/methods ([#22](https://github.com/samscott89/rudy/pull/22))
- Add function calling ([#21](https://github.com/samscott89/rudy/pull/21))
- Simplify lifetimes ([#19](https://github.com/samscott89/rudy/pull/19))
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.6](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.5...rudy-db-v0.0.6) - 2025-07-07

### Other

- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
- Support passing arguments to functions/methods ([#22](https://github.com/samscott89/rudy/pull/22))
- Add function calling ([#21](https://github.com/samscott89/rudy/pull/21))
- Simplify lifetimes ([#19](https://github.com/samscott89/rudy/pull/19))
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.5](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.4...rudy-lldb-v0.1.5) - 2025-07-07

### Other

- Support methods using string literals arguments ([#26](https://github.com/samscott89/rudy/pull/26))
- Support paths + generics ([#25](https://github.com/samscott89/rudy/pull/25))
- Support searching for methods by a type name ([#23](https://github.com/samscott89/rudy/pull/23))
- Support passing arguments to functions/methods ([#22](https://github.com/samscott89/rudy/pull/22))
- Add function calling ([#21](https://github.com/samscott89/rudy/pull/21))
- Simplify lifetimes ([#19](https://github.com/samscott89/rudy/pull/19))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).