### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ resolver = "3"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.6", path = "rudy-db" }
-rudy-dwarf = { version = "0.3.0", path = "crates/rudy-dwarf" }
+rudy-db = { version = "0.0.7", path = "rudy-db" }
+rudy-dwarf = { version = "0.3.1", path = "crates/rudy-dwarf" }
 rudy-types = { version = "0.4", path = "crates/rudy-types" }
 rudy-parser = { version = "0.4", path = "crates/rudy-parser" }
 rudy-test-examples = { path = "crates/rudy-test-examples" }

--- a/crates/rudy-dwarf/CHANGELOG.md
+++ b/crates/rudy-dwarf/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.3.0...rudy-dwarf-v0.3.1) - 2025-07-07
+
+### Other
+
+- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
+
 ## [0.3.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.2.0...rudy-dwarf-v0.3.0) - 2025-07-07
 
 ### Other

--- a/crates/rudy-dwarf/Cargo.toml
+++ b/crates/rudy-dwarf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-dwarf"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "DWARF debug information parsing and querying for Rust debugging tools"
 license = "MIT"

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.0...rudy-types-v0.4.1) - 2025-07-07
+
+### Other
+
+- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
+
 ## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-types-v0.3.0...rudy-types-v0.4.0) - 2025-07-07
 
 ### Other

--- a/crates/rudy-types/Cargo.toml
+++ b/crates/rudy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-types"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "Type layouts of common Rust types for Rudy"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.7](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.6...rudy-db-v0.0.7) - 2025-07-07
+
+### Other
+
+- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
+
 ## [0.0.6](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.5...rudy-db-v0.0.6) - 2025-07-07
 
 ### Other

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.5...rudy-lldb-v0.1.6) - 2025-07-07
+
+### Other
+
+- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
+
 ## [0.1.5](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.4...rudy-lldb-v0.1.5) - 2025-07-07
 
 ### Other

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `rudy-dwarf`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `rudy-db`: 0.0.6 -> 0.0.7 (⚠ API breaking changes)
* `rudy-lldb`: 0.1.5 -> 0.1.6

### ⚠ `rudy-db` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  DebugInfo::address_to_line, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:102
  DebugInfo::resolve_address_to_location, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:193
  DebugInfo::resolve_position, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:232
  DebugInfo::read_variable, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:488
  DebugInfo::resolve_variables_at_address, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:538
  DebugInfo::resolve_type, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:623
  DebugInfo::get_field, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:671
  DebugInfo::get_index_by_int, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:745
  DebugInfo::get_index_by_value, previously in file /tmp/.tmpVZAHTK/rudy-db/src/debug_info.rs:877

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/trait_method_missing.ron

Failed in:
  method base_address of trait DataResolver, previously in file /tmp/.tmpVZAHTK/rudy-db/src/data.rs:59
  method aslr_slide of trait DataResolver, previously in file /tmp/.tmpVZAHTK/rudy-db/src/data.rs:68
  method get_registers of trait DataResolver, previously in file /tmp/.tmpVZAHTK/rudy-db/src/data.rs:120
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.0...rudy-types-v0.4.1) - 2025-07-07

### Other

- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
</blockquote>

## `rudy-dwarf`

<blockquote>

## [0.3.1](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.3.0...rudy-dwarf-v0.3.1) - 2025-07-07

### Other

- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.7](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.6...rudy-db-v0.0.7) - 2025-07-07

### Other

- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.6](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.5...rudy-lldb-v0.1.6) - 2025-07-07

### Other

- Misc API cleanup ([#27](https://github.com/samscott89/rudy/pull/27))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).