### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ resolver = "3"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.7", path = "rudy-db" }
-rudy-dwarf = { version = "0.3.1", path = "crates/rudy-dwarf" }
+rudy-db = { version = "0.0.8", path = "rudy-db" }
+rudy-dwarf = { version = "0.4.0", path = "crates/rudy-dwarf" }
 rudy-types = { version = "0.4", path = "crates/rudy-types" }
 rudy-parser = { version = "0.4", path = "crates/rudy-parser" }
 rudy-test-examples = { path = "crates/rudy-test-examples" }

--- a/crates/rudy-dwarf/CHANGELOG.md
+++ b/crates/rudy-dwarf/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.3.1...rudy-dwarf-v0.4.0) - 2025-07-08
+
+### Other
+
+- Make all type resolution shallow ([#31](https://github.com/samscott89/rudy/pull/31))
+- Add a shiny new benchmark + tutorial ([#32](https://github.com/samscott89/rudy/pull/32))
+
 ## [0.3.1](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.3.0...rudy-dwarf-v0.3.1) - 2025-07-07
 
 ### Other

--- a/crates/rudy-dwarf/Cargo.toml
+++ b/crates/rudy-dwarf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-dwarf"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 description = "DWARF debug information parsing and querying for Rust debugging tools"
 license = "MIT"

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.1...rudy-types-v0.4.2) - 2025-07-08
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.0...rudy-types-v0.4.1) - 2025-07-07
 
 ### Other

--- a/crates/rudy-types/Cargo.toml
+++ b/crates/rudy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-types"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "Type layouts of common Rust types for Rudy"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.8](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.7...rudy-db-v0.0.8) - 2025-07-08
+
+### Other
+
+- Make all type resolution shallow ([#31](https://github.com/samscott89/rudy/pull/31))
+- Add a shiny new benchmark + tutorial ([#32](https://github.com/samscott89/rudy/pull/32))
+
 ## [0.0.7](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.6...rudy-db-v0.0.7) - 2025-07-07
 
 ### Other

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.6...rudy-lldb-v0.1.7) - 2025-07-08
+
+### Other
+
+- Add a shiny new benchmark + tutorial ([#32](https://github.com/samscott89/rudy/pull/32))
+
 ## [0.1.6](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.5...rudy-lldb-v0.1.6) - 2025-07-07
 
 ### Other

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `rudy-dwarf`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `rudy-db`: 0.0.7 -> 0.0.8 (✓ API compatible changes)
* `rudy-lldb`: 0.1.6 -> 0.1.7

### ⚠ `rudy-dwarf` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/function_missing.ron

Failed in:
  function rudy_dwarf::types::resolve_entry_type, previously in file /tmp/.tmpwgTT63/rudy-dwarf/src/types/resolution.rs:25

--- failure struct_now_doc_hidden: pub struct is now #[doc(hidden)] ---

Description:
A pub struct is now #[doc(hidden)], removing it from the crate's public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_now_doc_hidden.ron

Failed in:
  struct get_location_expr in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/expressions.rs:8
  struct resolve_function_variables in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/function/variables.rs:102
  struct resolve_function_signature in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/function/mod.rs:261
  struct get_die_typename in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/types/index.rs:12
  struct get_die_typename in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/types/index.rs:12
  struct index_debug_file_sources in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/file/index.rs:15
  struct module_index in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/modules.rs:234
  struct load in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/file/mod.rs:150
  struct function_index in file /tmp/.tmpkGxqMa/rudy/crates/rudy-dwarf/src/function/index.rs:202
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.4.2](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.1...rudy-types-v0.4.2) - 2025-07-08

### Other

- update Cargo.toml dependencies
</blockquote>

## `rudy-dwarf`

<blockquote>

## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.3.1...rudy-dwarf-v0.4.0) - 2025-07-08

### Other

- Make all type resolution shallow ([#31](https://github.com/samscott89/rudy/pull/31))
- Add a shiny new benchmark + tutorial ([#32](https://github.com/samscott89/rudy/pull/32))
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.8](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.7...rudy-db-v0.0.8) - 2025-07-08

### Other

- Make all type resolution shallow ([#31](https://github.com/samscott89/rudy/pull/31))
- Add a shiny new benchmark + tutorial ([#32](https://github.com/samscott89/rudy/pull/32))
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.7](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.6...rudy-lldb-v0.1.7) - 2025-07-08

### Other

- Add a shiny new benchmark + tutorial ([#32](https://github.com/samscott89/rudy/pull/32))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).