### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ resolver = "3"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.8", path = "rudy-db" }
-rudy-dwarf = { version = "0.4.0", path = "crates/rudy-dwarf" }
+rudy-db = { version = "0.0.9", path = "rudy-db" }
+rudy-dwarf = { version = "0.4.1", path = "crates/rudy-dwarf" }
 rudy-types = { version = "0.4", path = "crates/rudy-types" }
 rudy-parser = { version = "0.4", path = "crates/rudy-parser" }
 rudy-test-examples = { path = "crates/rudy-test-examples" }

--- a/crates/rudy-dwarf/CHANGELOG.md
+++ b/crates/rudy-dwarf/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.4.0...rudy-dwarf-v0.4.1) - 2025-07-26
+
+### Other
+
+- Add rudy-lldb as a test artifact ([#40](https://github.com/samscott89/rudy/pull/40))
+
 ## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.3.1...rudy-dwarf-v0.4.0) - 2025-07-08
 
 ### Other

--- a/crates/rudy-dwarf/Cargo.toml
+++ b/crates/rudy-dwarf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-dwarf"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "DWARF debug information parsing and querying for Rust debugging tools"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.9](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.8...rudy-db-v0.0.9) - 2025-07-26
+
+### Added
+
+- Better installation and setup ([#39](https://github.com/samscott89/rudy/pull/39))
+
+### Other
+
+- Add rudy-lldb as a test artifact ([#40](https://github.com/samscott89/rudy/pull/40))
+- Fix manual installation step. ([#37](https://github.com/samscott89/rudy/pull/37))
+- Expand the readme a little ([#36](https://github.com/samscott89/rudy/pull/36))
+- Add some basic installation instructions for rudy-lldb ([#34](https://github.com/samscott89/rudy/pull/34))
+
 ## [0.0.8](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.7...rudy-db-v0.0.8) - 2025-07-08
 
 ### Other

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.8"
+version = "0.0.9"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.7...rudy-lldb-v0.1.8) - 2025-07-26
+
+### Added
+
+- Better installation and setup ([#39](https://github.com/samscott89/rudy/pull/39))
+
 ## [0.1.7](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.6...rudy-lldb-v0.1.7) - 2025-07-08
 
 ### Other

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-dwarf`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `rudy-db`: 0.0.8 -> 0.0.9 (✓ API compatible changes)
* `rudy-lldb`: 0.1.7 -> 0.1.8

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-dwarf`

<blockquote>

## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.4.0...rudy-dwarf-v0.4.1) - 2025-07-26

### Other

- Add rudy-lldb as a test artifact ([#40](https://github.com/samscott89/rudy/pull/40))
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.9](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.8...rudy-db-v0.0.9) - 2025-07-26

### Added

- Better installation and setup ([#39](https://github.com/samscott89/rudy/pull/39))

### Other

- Add rudy-lldb as a test artifact ([#40](https://github.com/samscott89/rudy/pull/40))
- Fix manual installation step. ([#37](https://github.com/samscott89/rudy/pull/37))
- Expand the readme a little ([#36](https://github.com/samscott89/rudy/pull/36))
- Add some basic installation instructions for rudy-lldb ([#34](https://github.com/samscott89/rudy/pull/34))
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.8](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.7...rudy-lldb-v0.1.8) - 2025-07-26

### Added

- Better installation and setup ([#39](https://github.com/samscott89/rudy/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).