### PR TITLE
chore: fix compiler warnings on nightly

### DIFF
--- a/crates/rudy-dwarf/src/file/mod.rs
+++ b/crates/rudy-dwarf/src/file/mod.rs
@@ -211,7 +211,7 @@ impl SourceFile {
         Self { path }
     }
 
-    pub fn path_str(&self) -> std::borrow::Cow<str> {
+    pub fn path_str(&self) -> std::borrow::Cow<'_, str> {
         self.path.to_string_lossy()
     }
 

--- a/rudy-db/src/index.rs
+++ b/rudy-db/src/index.rs
@@ -32,7 +32,7 @@ impl<'db> Index<'db> {
         &self,
         db: &'db dyn Db,
         name: &SymbolName,
-    ) -> Option<(DebugFile, FunctionIndexEntry)> {
+    ) -> Option<(DebugFile, FunctionIndexEntry<'_>)> {
         let symbol_index = self.symbol_index(db);
         let sym = symbol_index
             .get_functions_by_lookup_name(&name.lookup_name)?


### PR DESCRIPTION
Fix the `mismatched_lifetime_syntaxes` lint that produces a compiler warning on nightly.

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> crates/rudy-dwarf/src/file/mod.rs:214:21
    |
214 |     pub fn path_str(&self) -> std::borrow::Cow<str> {
    |                     ^^^^^     --------------------- the same lifetime is hidden here
    |                     |
    |                     the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
214 |     pub fn path_str(&self) -> std::borrow::Cow<'_, str> {
    |                                                +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> rudy-db/src/index.rs:32:9
   |
32 |         &self,
   |         ^^^^^ the lifetime is elided here
...
35 |     ) -> Option<(DebugFile, FunctionIndexEntry)> {
   |                             ------------------ the same lifetime is hidden here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
35 |     ) -> Option<(DebugFile, FunctionIndexEntry<'_>)> {
   |                                               ++++
```