### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ rust-version = "1.89.0"
 
 [workspace.dependencies]
 # internal deps
-rudy-db = { version = "0.0.9", path = "rudy-db" }
-rudy-dwarf = { version = "0.4.1", path = "crates/rudy-dwarf" }
+rudy-db = { version = "0.0.10", path = "rudy-db" }
+rudy-dwarf = { version = "0.4.2", path = "crates/rudy-dwarf" }
 rudy-types = { version = "0.4", path = "crates/rudy-types" }
 rudy-parser = { version = "0.4", path = "crates/rudy-parser" }
 rudy-test-examples = { path = "crates/rudy-test-examples" }

--- a/crates/rudy-dwarf/CHANGELOG.md
+++ b/crates/rudy-dwarf/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.4.1...rudy-dwarf-v0.4.2) - 2025-08-09
+
+### Other
+
+- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
+- fix compiler warnings on nightly ([#42](https://github.com/samscott89/rudy/pull/42))
+
 ## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.4.0...rudy-dwarf-v0.4.1) - 2025-07-26
 
 ### Other

--- a/crates/rudy-dwarf/Cargo.toml
+++ b/crates/rudy-dwarf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-dwarf"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "DWARF debug information parsing and querying for Rust debugging tools"
 license = "MIT"

--- a/crates/rudy-parser/CHANGELOG.md
+++ b/crates/rudy-parser/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-parser-v0.4.0...rudy-parser-v0.4.1) - 2025-08-09
+
+### Other
+
+- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
+
 ## [0.4.0](https://github.com/samscott89/rudy/compare/rudy-parser-v0.3.0...rudy-parser-v0.4.0) - 2025-07-07
 
 ### Other

--- a/crates/rudy-parser/Cargo.toml
+++ b/crates/rudy-parser/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rudy-parser"
 description = "Simple Rust type and expression parser for Rudy"
 license = "MIT"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version.workspace = true
 

--- a/crates/rudy-types/CHANGELOG.md
+++ b/crates/rudy-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.2...rudy-types-v0.4.3) - 2025-08-09
+
+### Other
+
+- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
+
 ## [0.4.2](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.1...rudy-types-v0.4.2) - 2025-07-08
 
 ### Other

--- a/crates/rudy-types/Cargo.toml
+++ b/crates/rudy-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-types"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "Type layouts of common Rust types for Rudy"
 license = "MIT"

--- a/rudy-db/CHANGELOG.md
+++ b/rudy-db/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.10](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.9...rudy-db-v0.0.10) - 2025-08-09
+
+### Other
+
+- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
+- fix compiler warnings on nightly ([#42](https://github.com/samscott89/rudy/pull/42))
+
 ## [0.0.9](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.8...rudy-db-v0.0.9) - 2025-07-26
 
 ### Added

--- a/rudy-db/Cargo.toml
+++ b/rudy-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-db"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2024"
 authors = ["Sam Scott"]
 description = "A user-friendly library for interacting with debugging information of Rust compiled artifacts using DWARF"

--- a/rudy-lldb/CHANGELOG.md
+++ b/rudy-lldb/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.8...rudy-lldb-v0.1.9) - 2025-08-09
+
+### Added
+
+- *(rudy-lldb)* add `--yes` flag to `install` command ([#41](https://github.com/samscott89/rudy/pull/41))
+
+### Other
+
+- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
+
 ## [0.1.8](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.7...rudy-lldb-v0.1.8) - 2025-07-26
 
 ### Added

--- a/rudy-lldb/Cargo.toml
+++ b/rudy-lldb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudy-lldb"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 default-run = "rudy-lldb-server"
 description = "Rudy LLDB server for debugging Rust programs"


### PR DESCRIPTION



## 🤖 New release

* `rudy-types`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `rudy-parser`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `rudy-dwarf`: 0.4.1 -> 0.4.2 (✓ API compatible changes)
* `rudy-db`: 0.0.9 -> 0.0.10 (✓ API compatible changes)
* `rudy-lldb`: 0.1.8 -> 0.1.9

<details><summary><i><b>Changelog</b></i></summary><p>

## `rudy-types`

<blockquote>

## [0.4.3](https://github.com/samscott89/rudy/compare/rudy-types-v0.4.2...rudy-types-v0.4.3) - 2025-08-09

### Other

- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
</blockquote>

## `rudy-parser`

<blockquote>

## [0.4.1](https://github.com/samscott89/rudy/compare/rudy-parser-v0.4.0...rudy-parser-v0.4.1) - 2025-08-09

### Other

- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
</blockquote>

## `rudy-dwarf`

<blockquote>

## [0.4.2](https://github.com/samscott89/rudy/compare/rudy-dwarf-v0.4.1...rudy-dwarf-v0.4.2) - 2025-08-09

### Other

- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
- fix compiler warnings on nightly ([#42](https://github.com/samscott89/rudy/pull/42))
</blockquote>

## `rudy-db`

<blockquote>

## [0.0.10](https://github.com/samscott89/rudy/compare/rudy-db-v0.0.9...rudy-db-v0.0.10) - 2025-08-09

### Other

- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
- fix compiler warnings on nightly ([#42](https://github.com/samscott89/rudy/pull/42))
</blockquote>

## `rudy-lldb`

<blockquote>

## [0.1.9](https://github.com/samscott89/rudy/compare/rudy-lldb-v0.1.8...rudy-lldb-v0.1.9) - 2025-08-09

### Added

- *(rudy-lldb)* add `--yes` flag to `install` command ([#41](https://github.com/samscott89/rudy/pull/41))

### Other

- Set rust-version ([#45](https://github.com/samscott89/rudy/pull/45))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).